### PR TITLE
[ fix ] use backtracking to resolve transitive dependencies

### DIFF
--- a/src/Idris/Package/Types.idr
+++ b/src/Idris/Package/Types.idr
@@ -93,10 +93,14 @@ current = let (maj,min,patch) = semVer version
               version = Just (MkPkgVersion (maj ::: [min, patch])) in
               MkPkgVersionBounds version True version True
 
+export %inline
+defaultVersion : PkgVersion
+defaultVersion = MkPkgVersion $ 0 ::: []
+
 export
 inBounds : Maybe PkgVersion -> PkgVersionBounds -> Bool
 inBounds mv bounds
-   = let v = fromMaybe (MkPkgVersion (0 ::: [])) mv in
+   = let v = fromMaybe defaultVersion mv in
      maybe True (\v' => if bounds.lowerInclusive
                            then v >= v'
                            else v > v') bounds.lowerBound &&

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -90,40 +90,51 @@ localPackageDir
          let depends = depends_dir (dirs (options defs))
          pure $ srcdir </> depends
 
+||| Find all package directories (plus version) matching
+||| the given package name and version bounds. Results
+||| will be sorted with the latest package version first.
+export
+findPkgDirs :
+    Ref Ctxt Defs =>
+    String ->
+    PkgVersionBounds ->
+    Core (List (String, Maybe PkgVersion))
+findPkgDirs p bounds = do
+  defs <- get Ctxt
+  globaldir <- globalPackageDir
+  localdir <- localPackageDir
+
+  -- Get candidate directories from the global install location,
+  -- and the local package directory
+  locFiles <- coreLift $ candidateDirs localdir p bounds
+  globFiles <- coreLift $ candidateDirs globaldir p bounds
+  -- Look in all the package paths too
+  let pkgdirs = (options defs).dirs.package_dirs
+  pkgFiles <- coreLift $ traverse (\d => candidateDirs d p bounds) pkgdirs
+
+  -- If there's anything locally, use that and ignore the global ones
+  let allFiles = if isNil locFiles
+                    then globFiles ++ concat pkgFiles
+                    else locFiles
+  -- Sort in reverse order of version number
+  pure $ sortBy (\x, y => compare (snd y) (snd x)) allFiles
+
 export
 findPkgDir :
     Ref Ctxt Defs =>
     String ->
     PkgVersionBounds ->
     Core (Maybe String)
-findPkgDir p bounds
-    = do defs <- get Ctxt
-         globaldir <- globalPackageDir
-         localdir <- localPackageDir
+findPkgDir p bounds = do
+  defs <- get Ctxt
+  [] <- findPkgDirs p bounds | ((p,_) :: _) => pure (Just p)
 
-         -- Get candidate directories from the global install location,
-         -- and the local package directory
-         locFiles <- coreLift $ candidateDirs localdir p bounds
-         globFiles <- coreLift $ candidateDirs globaldir p bounds
-         -- Look in all the package paths too
-         let pkgdirs = (options defs).dirs.package_dirs
-         pkgFiles <- coreLift $ traverse (\d => candidateDirs d p bounds) pkgdirs
-
-         -- If there's anything locally, use that and ignore the global ones
-         let allFiles = if isNil locFiles
-                           then globFiles ++ concat pkgFiles
-                           else locFiles
-         -- Sort in reverse order of version number
-         let sorted = sortBy (\x, y => compare (snd y) (snd x)) allFiles
-
-         -- From what remains, pick the one with the highest version number.
-         -- If there's none, report it
-         -- (TODO: Can't do this quite yet due to idris2 build system...)
-         case sorted of
-              [] => if defs.options.session.ignoreMissingPkg
-                       then pure Nothing
-                       else throw (CantFindPackage (p ++ " (" ++ show bounds ++ ")"))
-              ((p, _) :: ps) => pure $ Just p
+  -- From what remains, pick the one with the highest version number.
+  -- If there's none, report it
+  -- (TODO: Can't do this quite yet due to idris2 build system...)
+  if defs.options.session.ignoreMissingPkg
+     then pure Nothing
+     else throw (CantFindPackage (p ++ " (" ++ show bounds ++ ")"))
 
 export
 addPkgDir : {auto c : Ref Ctxt Defs} ->

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -234,7 +234,8 @@ idrisTestsWith = MkTestPool "With abstraction" [] Nothing
 idrisTestsIPKG : TestPool
 idrisTestsIPKG = MkTestPool "Package and .ipkg files" [] Nothing
       ["pkg001", "pkg002", "pkg003", "pkg004", "pkg005", "pkg006", "pkg007",
-       "pkg008", "pkg009", "pkg010", "pkg011", "pkg012"]
+       "pkg008", "pkg009", "pkg010", "pkg011", "pkg012", "pkg013", "pkg014",
+       "pkg015"]
 
 idrisTests : TestPool
 idrisTests = MkTestPool "Misc" [] Nothing

--- a/tests/idris2/pkg006/expected
+++ b/tests/idris2/pkg006/expected
@@ -1,3 +1,7 @@
-Uncaught error: Can't find package foo (>= 0.4 && < 0.5)
-Uncaught error: Can't find package baz (any)
+Uncaught error: EmptyFC:Failed to resolve the dependencies for test3:
+  foo >= 0.4 && < 0.5: no matching version installed
+
+Uncaught error: EmptyFC:Failed to resolve the dependencies for test4:
+  baz any: no matching version installed
+
 [38;5;3;1mWarning:[0m Deprecation warning: version numbers must now be of the form x.y.z

--- a/tests/idris2/pkg014/.gitignore
+++ b/tests/idris2/pkg014/.gitignore
@@ -1,0 +1,2 @@
+/expected
+

--- a/tests/idris2/pkg014/depends/bar-0.1.0/bar.ipkg
+++ b/tests/idris2/pkg014/depends/bar-0.1.0/bar.ipkg
@@ -1,0 +1,3 @@
+package bar
+version = 0.1.0
+depends = baz >= 0.1.0

--- a/tests/idris2/pkg014/depends/bar-0.1.1/bar.ipkg
+++ b/tests/idris2/pkg014/depends/bar-0.1.1/bar.ipkg
@@ -1,0 +1,3 @@
+package bar
+version = 0.1.1
+depends = baz < 0.2.0

--- a/tests/idris2/pkg014/depends/baz-0.1.0/baz.ipkg
+++ b/tests/idris2/pkg014/depends/baz-0.1.0/baz.ipkg
@@ -1,0 +1,2 @@
+package baz
+version = 0.1.0

--- a/tests/idris2/pkg014/depends/baz-0.2.0/baz.ipkg
+++ b/tests/idris2/pkg014/depends/baz-0.2.0/baz.ipkg
@@ -1,0 +1,2 @@
+package baz
+version = 0.2.0

--- a/tests/idris2/pkg014/depends/baz-0.3.0/baz.ipkg
+++ b/tests/idris2/pkg014/depends/baz-0.3.0/baz.ipkg
@@ -1,0 +1,4 @@
+package baz
+version = 0.3.0
+
+depends = quux

--- a/tests/idris2/pkg014/depends/foo-0.1.0/foo.ipkg
+++ b/tests/idris2/pkg014/depends/foo-0.1.0/foo.ipkg
@@ -1,0 +1,3 @@
+package foo
+version = 0.1.0
+depends = baz < 0.1.0

--- a/tests/idris2/pkg014/depends/foo-0.2.0/foo.ipkg
+++ b/tests/idris2/pkg014/depends/foo-0.2.0/foo.ipkg
@@ -1,0 +1,3 @@
+package foo
+version = 0.2.0
+depends = baz >= 0.2.0

--- a/tests/idris2/pkg014/depends/foo-0.3.0/foo.ipkg
+++ b/tests/idris2/pkg014/depends/foo-0.3.0/foo.ipkg
@@ -1,0 +1,3 @@
+package foo
+version = 0.3.0
+depends = baz >= 0.3.0

--- a/tests/idris2/pkg014/expected.in
+++ b/tests/idris2/pkg014/expected.in
@@ -1,0 +1,1 @@
+LOG package.depends:10: all depends: ["__PWD__depends/bar-0.1.0", "__PWD__depends/baz-0.2.0", "__PWD__depends/foo-0.2.0"]

--- a/tests/idris2/pkg014/gen_expected.sh
+++ b/tests/idris2/pkg014/gen_expected.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+sed -e "s|__PWD__|${MY_PWD}|g" expected.in >expected

--- a/tests/idris2/pkg014/run
+++ b/tests/idris2/pkg014/run
@@ -1,0 +1,9 @@
+if [ "$OS" = "windows" ]; then
+    MY_PWD="$(cygpath -m "$(pwd)")\\\\"
+else
+    MY_PWD="$(pwd)/"
+fi
+
+MY_PWD="${MY_PWD}" ./gen_expected.sh
+
+$1 --build test.ipkg --log package.depends:10

--- a/tests/idris2/pkg014/test.ipkg
+++ b/tests/idris2/pkg014/test.ipkg
@@ -1,0 +1,20 @@
+-- dependencies:
+--
+-- test
+-- |_______
+-- |       |
+-- foo     bar
+-- |       |_____
+-- |       |     |
+-- baz     baz   (quux for bar >= 0.3)
+--
+-- We can't use the latest foo, because we have a <= 0.2.0 restriction.
+-- We also can't use foo-0.1.0, because it transitively depends on baz < 0.1.0,
+-- which is not installed. So foo-0.2.0 it is.
+--
+-- foo-0.2.0 requires baz >= 0.2.0, but baz-0.3.0 requires quux, which is
+-- not installed. So baz-0.2.0 it is. So, we can't use bar-0.1.1,
+-- which requires baz < 0.2.0. Hence, bar-0.1.0 it is.
+package test
+depends = foo <= 0.2.0
+        , bar >= 0.1.0

--- a/tests/idris2/pkg015/depends/bar-0.1.0/bar.ipkg
+++ b/tests/idris2/pkg015/depends/bar-0.1.0/bar.ipkg
@@ -1,0 +1,4 @@
+package bar
+version = 0.1.0
+depends = baz >= 0.1.0
+        , prz > 0.1.0

--- a/tests/idris2/pkg015/depends/bar-0.1.1/bar.ipkg
+++ b/tests/idris2/pkg015/depends/bar-0.1.1/bar.ipkg
@@ -1,0 +1,3 @@
+package bar
+version = 0.1.1
+depends = baz < 0.2.0

--- a/tests/idris2/pkg015/depends/baz-0.1.0/baz.ipkg
+++ b/tests/idris2/pkg015/depends/baz-0.1.0/baz.ipkg
@@ -1,0 +1,2 @@
+package baz
+version = 0.1.0

--- a/tests/idris2/pkg015/depends/baz-0.2.0/baz.ipkg
+++ b/tests/idris2/pkg015/depends/baz-0.2.0/baz.ipkg
@@ -1,0 +1,2 @@
+package baz
+version = 0.2.0

--- a/tests/idris2/pkg015/depends/baz-0.3.0/baz.ipkg
+++ b/tests/idris2/pkg015/depends/baz-0.3.0/baz.ipkg
@@ -1,0 +1,4 @@
+package baz
+version = 0.3.0
+
+depends = quux

--- a/tests/idris2/pkg015/depends/foo-0.1.0/foo.ipkg
+++ b/tests/idris2/pkg015/depends/foo-0.1.0/foo.ipkg
@@ -1,0 +1,3 @@
+package foo
+version = 0.1.0
+depends = baz < 0.1.0

--- a/tests/idris2/pkg015/depends/foo-0.2.0/foo.ipkg
+++ b/tests/idris2/pkg015/depends/foo-0.2.0/foo.ipkg
@@ -1,0 +1,3 @@
+package foo
+version = 0.2.0
+depends = baz >= 0.2.0

--- a/tests/idris2/pkg015/depends/foo-0.3.0/foo.ipkg
+++ b/tests/idris2/pkg015/depends/foo-0.3.0/foo.ipkg
@@ -1,0 +1,3 @@
+package foo
+version = 0.3.0
+depends = baz >= 0.3.0

--- a/tests/idris2/pkg015/depends/prz-0.1.0/prz.ipkg
+++ b/tests/idris2/pkg015/depends/prz-0.1.0/prz.ipkg
@@ -1,0 +1,2 @@
+package prz
+version = 0.1.0

--- a/tests/idris2/pkg015/expected
+++ b/tests/idris2/pkg015/expected
@@ -1,0 +1,6 @@
+Uncaught error: EmptyFC:Failed to resolve the dependencies for test:
+  foo-0.2.0; baz-0.3.0; required quux any but no matching version is installed
+  foo-0.2.0; baz-0.2.0; bar-0.1.1; required baz < 0.2.0 but assigned version 0.2.0 which is out of bounds
+  foo-0.2.0; baz-0.2.0; bar-0.1.0; required prz > 0.1.0 but no matching version is installed
+  foo-0.1.0; required baz < 0.1.0 but no matching version is installed
+

--- a/tests/idris2/pkg015/run
+++ b/tests/idris2/pkg015/run
@@ -1,0 +1,1 @@
+$1 --build test.ipkg --log package.depends:10

--- a/tests/idris2/pkg015/test.ipkg
+++ b/tests/idris2/pkg015/test.ipkg
@@ -1,0 +1,21 @@
+-- dependencies:
+--
+-- test
+-- |_______
+-- |       |
+-- foo     bar
+-- |       |_____
+-- |       |     |
+-- baz     baz   (quux for bar >= 0.3)
+--
+-- We can't use the latest foo, because we have a <= 0.2.0 restriction.
+-- We also can't use foo-0.1.0, because it transitively depends on baz < 0.1.0,
+-- which is not installed. So foo-0.2.0 it is.
+--
+-- foo-0.2.0 requires baz >= 0.2.0, but baz-0.3.0 requires quux, which is
+-- not installed. So baz-0.2.0 it is. So, we can't use bar-0.1.1,
+-- which requires baz < 0.2.0. Hence, bar-0.1.0 it is, but this
+-- requires prz, which is not installed. And so this fails.
+package test
+depends = foo <= 0.2.0
+        , bar >= 0.1.0


### PR DESCRIPTION
I also added two new test cases with somewhat more complex dependency graphs, one of which fails to make sure we generate reasonable error messages.